### PR TITLE
Use `bundle_contents` to store chestplate and original elytra

### DIFF
--- a/src/client/java/xyz/ashyboxy/mc/metalwings/mixin/client/HumanoidArmorLayerMixin.java
+++ b/src/client/java/xyz/ashyboxy/mc/metalwings/mixin/client/HumanoidArmorLayerMixin.java
@@ -3,24 +3,26 @@ package xyz.ashyboxy.mc.metalwings.mixin.client;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtOps;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.item.component.BundleContents;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import xyz.ashyboxy.mc.metalwings.ArmoredElytra;
 
 @Mixin(HumanoidArmorLayer.class)
 public class HumanoidArmorLayerMixin {
     @ModifyVariable(method = "renderArmorPiece", at = @At("STORE"), ordinal = 0)
     private ItemStack replaceElytraWithChestplate(ItemStack itemStack) {
         if (!itemStack.is(Items.ELYTRA) || Minecraft.getInstance().player == null) return itemStack;
-        CompoundTag chestplateData =
-                itemStack.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag().getCompound(ArmoredElytra.CHESTPLATE_DATA.toString());
-        if (chestplateData.isEmpty()) return itemStack;
-        return ItemStack.SINGLE_ITEM_CODEC.decode(Minecraft.getInstance().player.registryAccess().createSerializationContext(NbtOps.INSTANCE), chestplateData).getOrThrow().getFirst();
+        Iterable<ItemStack> bundleContents = itemStack.getOrDefault(DataComponents.BUNDLE_CONTENTS, BundleContents.EMPTY).items();
+
+        for (ItemStack item : bundleContents) {
+            if (item.is(ItemTags.CHEST_ARMOR)) {
+                return item;
+            }
+        }
+        return itemStack;
     }
 }

--- a/src/main/java/xyz/ashyboxy/mc/metalwings/ArmoredElytra.java
+++ b/src/main/java/xyz/ashyboxy/mc/metalwings/ArmoredElytra.java
@@ -76,8 +76,13 @@ public class ArmoredElytra {
         // determines which attribute is applied (assuming you pass the itemstacks in that order)
         LinkedHashMap<Attribute, ItemAttributeModifiers.Entry> attributes = new LinkedHashMap<>();
         for (ItemStack itemStack : itemStacks) {
-            itemStack.getItem().components().getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY)
-                    .modifiers().forEach(a -> attributes.put(a.attribute().value(), a));
+            if (itemStack.is(ItemTags.CHEST_ARMOR)) {
+                ArmorItem armorItem = (ArmorItem) itemStack.getItem();
+                armorItem.getDefaultAttributeModifiers().modifiers().forEach(a -> attributes.put(a.attribute().value(), a));
+            } else {
+                itemStack.getItem().components().getOrDefault(DataComponents.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.EMPTY)
+                        .modifiers().forEach(a -> attributes.put(a.attribute().value(), a));
+            }
         }
         for (ItemStack itemStack : itemStacks) {
             ItemAttributeModifiers attributeModifiers =

--- a/src/main/java/xyz/ashyboxy/mc/metalwings/ArmoredElytra.java
+++ b/src/main/java/xyz/ashyboxy/mc/metalwings/ArmoredElytra.java
@@ -3,19 +3,16 @@ package xyz.ashyboxy.mc.metalwings;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtOps;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.item.component.BundleContents;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.component.ItemLore;
 
@@ -25,9 +22,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 public class ArmoredElytra {
-    public static final ResourceLocation ELYTRA_DATA = MetalWings.id("elytra");
-    public static final ResourceLocation CHESTPLATE_DATA = MetalWings.id("chestplate");
-
     public static ItemStack createChestplateElytra(ItemStack chestplate, ItemStack elytra, LocalIntRef cost,
                                                    ContainerLevelAccess access) {
         if (!(chestplate.is(ItemTags.CHEST_ARMOR) && chestplate.getItem() instanceof ArmorItem && elytra.is(Items.ELYTRA)))
@@ -38,15 +32,9 @@ public class ArmoredElytra {
         ItemStack output = elytra.copy();
         // item component types are server and client synced
         // (it gets angy if the server has component types the client doesn't)
-        CompoundTag customData = output.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
-
-        // there's probably a better way to do this(?)
-        access.execute((l, b) -> {
-            customData.put(ELYTRA_DATA.toString(),
-                    ItemStack.SINGLE_ITEM_CODEC.encodeStart(l.registryAccess().createSerializationContext(NbtOps.INSTANCE), elytra).getOrThrow());
-            customData.put(CHESTPLATE_DATA.toString(),
-                    ItemStack.SINGLE_ITEM_CODEC.encodeStart(l.registryAccess().createSerializationContext(NbtOps.INSTANCE), chestplate).getOrThrow());
-        });
+        List<ItemStack> bundleContents = new ArrayList<ItemStack>();
+        bundleContents.add(chestplate);
+        bundleContents.add(elytra);
 
         List<Component> lore = new ArrayList<>(elytra.getOrDefault(DataComponents.LORE, new ItemLore(Collections.emptyList())).lines());
 
@@ -63,7 +51,7 @@ public class ArmoredElytra {
         lore.addAll(chestplate.getOrDefault(DataComponents.LORE, new ItemLore(Collections.emptyList())).lines());
 
         output.set(DataComponents.LORE, new ItemLore(lore));
-        output.set(DataComponents.CUSTOM_DATA, CustomData.of(customData));
+        output.set(DataComponents.BUNDLE_CONTENTS, new BundleContents(bundleContents));
         cost.set(cost.get() + 1);
 
         output.set(DataComponents.ATTRIBUTE_MODIFIERS, mergeAttributeModifiers(chestplate, elytra));

--- a/src/main/java/xyz/ashyboxy/mc/metalwings/mixin/GrindstoneMenuMixin.java
+++ b/src/main/java/xyz/ashyboxy/mc/metalwings/mixin/GrindstoneMenuMixin.java
@@ -1,13 +1,13 @@
 package xyz.ashyboxy.mc.metalwings.mixin;
 
 import net.minecraft.core.component.DataComponents;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.NbtOps;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.*;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.component.BundleContents;
 import net.minecraft.world.level.block.LevelEvent;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
@@ -17,7 +17,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import xyz.ashyboxy.mc.metalwings.ArmoredElytra;
 
 @Mixin(GrindstoneMenu.class)
 public abstract class GrindstoneMenuMixin extends AbstractContainerMenu {
@@ -41,19 +40,18 @@ public abstract class GrindstoneMenuMixin extends AbstractContainerMenu {
         ItemStack input1 = this.repairSlots.getItem(0);
         ItemStack input2 = this.repairSlots.getItem(1);
 
-        CompoundTag customData =
-                input1.getOrDefault(DataComponents.CUSTOM_DATA, CustomData.EMPTY).copyTag();
-        CompoundTag chestplateData = customData.getCompound(ArmoredElytra.CHESTPLATE_DATA.toString());
-
-        if (customData.getCompound(ArmoredElytra.ELYTRA_DATA.toString()).isEmpty() || chestplateData.isEmpty())
-            return;
         if (!input2.isEmpty()) {
             this.resultSlots.setItem(0, ItemStack.EMPTY);
             return;
         }
-        access.execute((l, b) -> this.resultSlots.setItem(0,
-                ItemStack.SINGLE_ITEM_CODEC.decode(l.registryAccess().createSerializationContext(NbtOps.INSTANCE)
-                        , chestplateData).getOrThrow().getFirst()));
+
+        Iterable<ItemStack> bundleContents = input1.getOrDefault(DataComponents.BUNDLE_CONTENTS, BundleContents.EMPTY).items();
+        bundleContents.forEach(item -> {
+            if (item.is(ItemTags.CHEST_ARMOR)) {
+                this.resultSlots.setItem(0, item);
+                return;
+            }
+        });
     }
 
     @Mixin(GrindstoneMenu.class)
@@ -78,15 +76,16 @@ public abstract class GrindstoneMenuMixin extends AbstractContainerMenu {
 
         @Inject(method = "onTake", at = @At("HEAD"), cancellable = true)
         private void takeSeparatedChestplate(Player player, ItemStack stack, CallbackInfo ci) {
-            CompoundTag customData =
-                    ((GrindStoneMenuAccessor) field_16780).getRepairSlots().getItem(0).getOrDefault(DataComponents.CUSTOM_DATA,
-                            CustomData.EMPTY).copyTag();
-            CompoundTag elytraData = customData.getCompound(ArmoredElytra.ELYTRA_DATA.toString());
-            if (elytraData.isEmpty() || customData.getCompound(ArmoredElytra.CHESTPLATE_DATA.toString()).isEmpty()) return;
-            val$access.execute((level, blockPos) -> {
-                level.levelEvent(LevelEvent.SOUND_GRINDSTONE_USED, blockPos, 0);
-                ((GrindStoneMenuAccessor) field_16780).getRepairSlots().setItem(0,
-                        ItemStack.SINGLE_ITEM_CODEC.decode(level.registryAccess().createSerializationContext(NbtOps.INSTANCE), elytraData).getOrThrow().getFirst());
+            Iterable<ItemStack> bundleContents =
+                    ((GrindStoneMenuAccessor) field_16780).getRepairSlots().getItem(0).getOrDefault(DataComponents.BUNDLE_CONTENTS,
+                            BundleContents.EMPTY).items();
+            bundleContents.forEach(item -> {
+                if (item.is(Items.ELYTRA)) {
+                    val$access.execute((level, blockPos) -> {
+                        level.levelEvent(LevelEvent.SOUND_GRINDSTONE_USED, blockPos, 0);
+                        ((GrindStoneMenuAccessor) field_16780).getRepairSlots().setItem(0, item);
+                    });
+                }
             });
             ci.cancel();
         }


### PR DESCRIPTION
This PR changes the data storage from using `custom_data` to using `bundle_contents`. This has a few benefits,

- It avoids having to serialize and deserialize the data with custom code in the mod,
- It stores the data in the same format as Vanilla Tweak's datapack in 1.20.5+, making the armored elytra compatible between the mod and the datapack.

Includes my previous PR #3 